### PR TITLE
fix(pr-triage.js): listen dismiss event

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ function probotPlugin(robot) {
     "pull_request.edited",
     "pull_request.synchronize",
     "pull_request.reopened",
-    "pull_request_review.submitted"
+    "pull_request_review.submitted",
+    "pull_request_review.dismissed"
   ];
 
   robot.on(events, triage);

--- a/lib/pr-triage.js
+++ b/lib/pr-triage.js
@@ -23,8 +23,7 @@ class PRTriage {
   static get GH_REVIEW_STATE() {
     return Object.freeze({
       APPROVED: "APPROVED",
-      CHANGES_REQUESTED: "CHANGES_REQUESTED",
-      COMMENTED: "COMMENTED"
+      CHANGES_REQUESTED: "CHANGES_REQUESTED"
     });
   }
 
@@ -111,7 +110,11 @@ class PRTriage {
 
     const uniqueReviews = reviews
       .filter(review => review.commit_id === sha)
-      .filter(review => review.state !== PRTriage.GH_REVIEW_STATE.COMMENTED)
+      .filter(
+        review =>
+          review.state === PRTriage.GH_REVIEW_STATE.APPROVED ||
+          review.state === PRTriage.GH_REVIEW_STATE.CHANGES_REQUESTED
+      )
       .reduce((reviewObj, review) => {
         if (
           reviewObj[review.user.id] === null ||

--- a/test/pr-triage.test.js
+++ b/test/pr-triage.test.js
@@ -23,8 +23,7 @@ describe("PRTriage", () => {
   describe("GH REVIEW STATE", () => {
     expect(PRTriage.GH_REVIEW_STATE).toEqual({
       APPROVED: "APPROVED",
-      CHANGES_REQUESTED: "CHANGES_REQUESTED",
-      COMMENTED: "COMMENTED"
+      CHANGES_REQUESTED: "CHANGES_REQUESTED"
     });
   }); // static GH_REVIEW_STATE
 


### PR DESCRIPTION
It does not listen dismiss event which is happen when user dismiss their review. This issue was
reported by @nesl247. We appreciate your feedback. Thanks a lot.

fix #78 

ref https://github.com/pr-triage/sandbox/pull/6