### PR TITLE
fix: forgotten labels

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,23 +1,23 @@
 module.exports = {
   wipRegex: /^\s*(\[WIP\]\s*|WIP:\s*|WIP\s+)+\s*/i,
   labelUnreviewed: {
-    name: "Status: Review Needed :passport_control:",
-    color: "FFFFFF"
+    name: "PR: unreviewed",
+    color: "fbca04"
   },
   labelInReview: {
-    name: "Status: In Review :detective:",
-    color: "00FFFF"
+    name: "PR: in-review",
+    color: "ed3fee"
   },
   labelApproved: {
-    name: "Status: Accepted :heavy_check_mark:",
-    color: "00FF00"
+    name: "PR: reviewed-approved",
+    color: "0e8a16"
   },
   labelChangesRequested: {
-    name: "Status: Changes requested",
+    name: "PR: reviewed-changes-requested",
     color: "c2e0c6"
   },
   labelMerged: {
-    name: "Status: Merged",
+    name: "PR: merged",
     color: "6f42c1"
   }
 };

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,19 +1,23 @@
 module.exports = {
   wipRegex: /^\s*(\[WIP\]\s*|WIP:\s*|WIP\s+)+\s*/i,
   labelUnreviewed: {
-    name: "PR: unreviewed",
-    color: "fbca04"
+    name: "Status: Review Needed :passport_control:",
+    color: "FFFFFF"
+  },
+  labelInReview: {
+    name: "Status: In Review :detective:",
+    color: "00FFFF"
   },
   labelApproved: {
-    name: "PR: reviewed-approved",
-    color: "0e8a16"
+    name: "Status: Accepted :heavy_check_mark:",
+    color: "00FF00"
   },
   labelChangesRequested: {
-    name: "PR: reviewed-changes-requested",
+    name: "Status: Changes requested",
     color: "c2e0c6"
   },
   labelMerged: {
-    name: "PR: merged",
+    name: "Status: Merged",
     color: "6f42c1"
   }
 };

--- a/lib/pr-triage.js
+++ b/lib/pr-triage.js
@@ -13,6 +13,7 @@ class PRTriage {
     return Object.freeze({
       WIP: "labelWip",
       UNREVIED: "labelUnreviewed",
+      IN_REVIEW: "labelInReview",
       APPROVED: "labelApproved",
       CHANGES_REQUESTED: "labelChangesRequested",
       MERGED: "labelMerged"
@@ -39,12 +40,13 @@ class PRTriage {
     switch (state) {
       case PRTriage.STATE.WIP:
       case PRTriage.STATE.UNREVIED:
+      case PRTriage.STATE.IN_REVIEW:
       case PRTriage.STATE.CHANGES_REQUESTED:
       case PRTriage.STATE.APPROVED:
       case PRTriage.STATE.MERGED:
         this._updateLabel(state);
         this.logger(
-          "%s/%s#%s is labeld as %s",
+          "%s/%s#%s is labelled as %s",
           owner,
           repo,
           number,
@@ -54,7 +56,7 @@ class PRTriage {
         );
         break;
       default:
-        throw new Error("Undefined state");
+        throw new Error(`Undefined state: "${state}"`);
     }
   }
 
@@ -80,7 +82,7 @@ class PRTriage {
         return PRTriage.STATE.CHANGES_REQUESTED;
       } else if (reviews.length === approvedReviews.length) {
         return PRTriage.STATE.APPROVED;
-      }
+      } else return PRTriage.STATE.IN_REVIEW;
     }
   }
 
@@ -195,10 +197,9 @@ class PRTriage {
         this._removeLabel(currentLabelKey);
         this._addLabel(labelKey);
       }
-    } else {
-      if (labelKey !== PRTriage.STATE.WIP) {
-        this._addLabel(labelKey);
-      }
+      //Maybe add some checks here
+    } else if (labelKey !== PRTriage.STATE.WIP) {
+      this._addLabel(labelKey);
     }
   }
 

--- a/test/fixtures/payload.json
+++ b/test/fixtures/payload.json
@@ -20,7 +20,7 @@
       "unreviewed_label": {
         "data": {
           "title": "Pull Request with unreviewed label",
-          "labels": [{ "name": "Status: Review Needed :passport_control:" }],
+          "labels": [{ "name": "PR: unreviewed" }],
           "state": "open",
           "head": {
             "sha": "head"
@@ -30,7 +30,7 @@
       "reviewed_approved_label": {
         "data": {
           "title": "Pull Request with reviewed approved label",
-          "labels": [{ "name": "Status: Accepted :heavy_check_mark:" }],
+          "labels": [{ "name": "PR: reviewed-approved" }],
           "state": "open",
           "head": {
             "sha": "head"
@@ -40,7 +40,7 @@
       "reviewed_changes_requested_label": {
         "data": {
           "title": "Pull Request with reviewed changes requested",
-          "labels": [{ "name": "Status: Changes requested" }],
+          "labels": [{ "name": "PR: reviewed-changes-requested" }],
           "state": "open",
           "head": {
             "sha": "head"

--- a/test/fixtures/payload.json
+++ b/test/fixtures/payload.json
@@ -9,7 +9,7 @@
       "merged": {
         "data": {
           "title": "Pull Request with unreviewed and merged",
-          "labels": [{ "name": "PR: unreviewed" }],
+          "labels": [{ "name": "Status: Review Needed :passport_control:" }],
           "state": "closed",
           "head": {
             "sha": "head"
@@ -20,7 +20,7 @@
       "unreviewed_label": {
         "data": {
           "title": "Pull Request with unreviewed label",
-          "labels": [{ "name": "PR: unreviewed" }],
+          "labels": [{ "name": "Status: Review Needed :passport_control:" }],
           "state": "open",
           "head": {
             "sha": "head"
@@ -30,7 +30,7 @@
       "reviewed_approved_label": {
         "data": {
           "title": "Pull Request with reviewed approved label",
-          "labels": [{ "name": "PR: reviewed-approved" }],
+          "labels": [{ "name": "Status: Accepted :heavy_check_mark:" }],
           "state": "open",
           "head": {
             "sha": "head"
@@ -40,7 +40,7 @@
       "reviewed_changes_requested_label": {
         "data": {
           "title": "Pull Request with reviewed changes requested",
-          "labels": [{ "name": "PR: reviewed-changes-requested" }],
+          "labels": [{ "name": "Status: Changes requested" }],
           "state": "open",
           "head": {
             "sha": "head"

--- a/test/pr-triage.test.js
+++ b/test/pr-triage.test.js
@@ -1,5 +1,6 @@
 const PRTriage = require("../lib/pr-triage");
 const payload = require("./fixtures/payload");
+const defaults = require("../lib/defaults");
 
 describe("PRTriage", () => {
   const owner = "pr-triage";
@@ -220,7 +221,7 @@ describe("PRTriage", () => {
   describe("_ensurePRTriageLabelExists", () => {
     const klass = new PRTriage({}, { owner, repo });
     klass._createLabel = jest.fn().mockReturnValue(Promise.resolve({}));
-    const n = 4;
+    const n = 5; //5 labels
 
     test(`createLabel() should be called ${n} times`, async () => {
       await klass._ensurePRTriageLabelExists();
@@ -454,7 +455,7 @@ describe("PRTriage", () => {
     describe("when key exists", () => {
       const klass = new PRTriage({}, { owner, repo });
       const subject = argument => klass._getLabel(argument);
-      const desiredObj = { color: "fbca04", name: "PR: unreviewed" };
+      const desiredObj = defaults.labelUnreviewed;
 
       test("should be a label object", async () => {
         klass.pullRequest =
@@ -525,7 +526,7 @@ describe("PRTriage", () => {
     describe("when key exists", () => {
       const klass = new PRTriage({}, { owner, repo });
       const subject = argument => klass._getConfigObj(argument);
-      const desiredObj = { color: "fbca04", name: "PR: unreviewed" };
+      const desiredObj = defaults.labelUnreviewed;
 
       test("should be desiredObj", () => {
         expect(subject(PRTriage.STATE.UNREVIED)).toEqual(desiredObj);


### PR DESCRIPTION
There are no direct changes in the behaviour other than the fact that the bot fills in the gaps where one of the following isn't true:
- no reviews
- one review requesting changes
- all reviews were accepted

Which seems to be what steamed the issue in #119 where some labels (namely: "PR: unreviewed") were forgotten.

There are other minor changes that include a small loop fusion, typo fix and addition of a detail in an error report regarding statuses.
There are more things that could be improved but I decided to leave those for now.