### PR TITLE
Update for new Octokit

### DIFF
--- a/lib/pr-triage.js
+++ b/lib/pr-triage.js
@@ -94,7 +94,7 @@ class PRTriage {
     const sha = this.pullRequest.head.sha;
 
     const reviews =
-      (await this.github.pullRequests.listReviews({ owner, repo, pull_number }))
+      (await this.github.pulls.listReviews({ owner, repo, pull_number }))
         .data || [];
 
     const uniqueReviews = reviews


### PR DESCRIPTION
It seems like Octokit, the JS library for accessing the GitHub API, changed how Pull Requests are accessed, changing the name from `pullRequests` to `pulls`. This PR implements the name change

Closes #221